### PR TITLE
Allow using the library with any vibe.d version

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,6 +6,6 @@
     "authors": ["Yoplitein"],
     "targetType": "library",
     "dependencies": {
-        "vibe-d": "~>0.7.24"
+        "vibe-d": "*"
     }
 }


### PR DESCRIPTION
this library works with vibe.d 0.8.0 but it doesn't allow using it if the vibe version is fixed to 0.7.x